### PR TITLE
Push ServeSession to the start

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,11 +6,11 @@ This document is a "what the heck is going on" level view of Rojo and the codeba
 
 ## Overarching
 
-Rojo is divided into several components, each layering on top of each other provide Rojo's functionality.
+Rojo is divided into several components, each layering on top of each other to provide Rojo's functionality.
 
 At the core of Rojo lies [`ServeSession`](#servesession). As the name implies, it contains all of the components to keep a persistent DOM, react to events to update the DOM, and serve the DOM to consumers.
 
-Most of Rojo's uses are built upon `ServeSession`! For example, [`SourcemapCommand`](#sourcemapCommand) uses `ServeSession` to generate the DOM and read it to build the `sourcemap.json` file.
+Most of Rojo's uses are built upon `ServeSession`! For example, the [`sourcemap` command](#sourcemapcommand) uses `ServeSession` to generate the DOM and read it to build the `sourcemap.json` file.
 
 ### The Serve Command
 
@@ -18,7 +18,7 @@ There are two main pieces in play when serving: the server and the Studio plugin
 
 The server runs a local [`LiveServer`](#liveserver) with access to your filesystem (whether it be via the terminal, the visual studio code extension, or a remote machine). It consumes a `ServeSession` and attaches a web server on top. The web server itself is very basic, consisting of around half a dozen endpoints. Generally, [`LiveServer`](#liveserver) acts as a middleman with the bulk of the work is performed by either the underlying `ServeSession` or the plugin. 
 
-To serve a project to a connecting plugin, the server gathers data on all of the files in that project, puts it into a nice format, and then sends it to the plugin. After that, when something changes on the file system, the underlying `ServeSession` emits new patches. The web server has a `api/subscribe` endpoint where the plugin [long polls](https://en.wikipedia.org/wiki/Push_technology#Long_polling) to receive the patches from the server and apply them to the datamodel in Studio.
+To serve a project to a connecting plugin, the server gathers data on all of the files in that project, puts it into a nice format, and then sends it to the plugin. After that, when something changes on the file system, the underlying `ServeSession` emits new patches. The web server has an endpoint the plugin [long polls](https://en.wikipedia.org/wiki/Push_technology#Long_polling) to receive the patches from the server and apply them to the datamodel in Studio.
 
 When the plugin receives a patch it reads through the patch contents and attempts to to apply the changes described by it. Any sugar (the patch visualizer, as an example) happens on top of the patches received from the server.
 
@@ -54,17 +54,17 @@ To learn more, read about [`memofs` architecture](crates/memofs/ARCHITECTURE.md)
 
 ### LiveServer
 
-LiveServer underlies the [`serve` command](#the-serve-command) and provides the web server which clients (such as the plugin) can use to interface with [`ServeSession`](#servesession).
+LiveServer underlies the [`serve` command](#the-serve-command) and provides the web server which clients (such as the Studio plugin) can use to interface with a [`ServeSession`](#servesession).
 
-There's two parts to the API, the UI and the API clients use.
+The web server has two components: a UI and the API used by clients.
 
-The UI provides information about the current [`DOM`](#rojotree) has, including metadata. It also shows the project name, up-time, and version its Rojo is on.
+The UI provides information about the current project's [tree](#rojotree), including metadata. It also shows the project name, up-time, and version its Rojo is on.
 
 The API provides a simple JSON protocol to interact with and receive changes from the underlying [`ServeSession`](#servesession). Checkout the [`api.rs` file under the web module](src/web/api.rs) to learn more.
 
 ### ServeSession
 
-The linchpin of Rojo. It contains all of the required components to serve a given project file.
+The `ServeSession` is the core of Rojo. It contains all of the required components to serve a given project file.
 
 Generally, to serve means:
 
@@ -74,7 +74,7 @@ Generally, to serve means:
 
 It depends on:
 
-- `RojoTree` to represent the DOM;
+- [`RojoTree`](#rojotree) to represent the DOM;
 - `Project` to represent your root project file (e.g. `default.project.json`);
 - [`Vfs`](#vfs) to provide a filesystem and emit events on changes;
 - [`ChangeProcessor`](#changeprocessor) to process filesystem events from `Vfs` and consequently update the DOM through the [snapshotting system](#the-snapshotting-system);

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Most of Rojo's uses are built upon `ServeSession`! For example, [`SourcemapComma
 
 There are two main pieces in play when serving: the server and the Studio plugin.
 
-The server runs a local `LiveServer` with access to your filesystem (whether it be via the terminal, the visual studio code extension, or a remote machine). It consumes a `ServeSession` and attaches a web server on top. The web server itself is very basic, consisting of around half a dozen endpoints. Generally, `LiveServer` acts as a middleman with the bulk of the work is performed by either the underlying `ServeSession` or the plugin. 
+The server runs a local [`LiveServer`](#liveserver) with access to your filesystem (whether it be via the terminal, the visual studio code extension, or a remote machine). It consumes a `ServeSession` and attaches a web server on top. The web server itself is very basic, consisting of around half a dozen endpoints. Generally, [`LiveServer`](#liveserver) acts as a middleman with the bulk of the work is performed by either the underlying `ServeSession` or the plugin. 
 
 To serve a project to a connecting plugin, the server gathers data on all of the files in that project, puts it into a nice format, and then sends it to the plugin. After that, when something changes on the file system, the underlying `ServeSession` emits new patches. The web server has a `api/subscribe` endpoint where the plugin [long polls](https://en.wikipedia.org/wiki/Push_technology#Long_polling) to receive the patches from the server and apply them to the datamodel in Studio.
 
@@ -52,6 +52,16 @@ Rojo has many data structures and their purpose might not be immediately clear a
 
 To learn more, read about [`memofs` architecture](crates/memofs/ARCHITECTURE.md).
 
+### LiveServer
+
+LiveServer underlies the [`serve` command](#the-serve-command) and provides the web server which clients (such as the plugin) can use to interface with [`ServeSession`](#servesession).
+
+There's two parts to the API, the UI and the API clients use.
+
+The UI provides information about the current [`DOM`](#rojotree) has, including metadata. It also shows the project name, up-time, and version its Rojo is on.
+
+The API provides a simple JSON protocol to interact with and receive changes from the underlying [`ServeSession`](#servesession). Checkout the [`api.rs` file under the web module](src/web/api.rs) to learn more.
+
 ### ServeSession
 
 The linchpin of Rojo. It contains all of the required components to serve a given project file.
@@ -80,7 +90,5 @@ All of the public interfaces via CLI of Rojo are implemented using `ServeSession
 ### ChangeProcessor
 
 ### RojoTree
-
-### LifeServer
 
 ### InstanceSnapshot

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,13 +79,25 @@ It depends on:
 - [`Vfs`](#vfs) to provide a filesystem and emit events on changes;
 - [`ChangeProcessor`](#changeprocessor) to process filesystem events from `Vfs` and consequently update the DOM through the [snapshotting system](#the-snapshotting-system);
 
-It also provides an API for the higher level components so it can be used with the outside world.
+It also provides an API for the higher level components so it can be used with the outside world:
 
-- There is a `MessageQueue` of changes applied to the DOM.
-- There is a channel to send changes to the `ServeSession` and update the DOM.
+- There is a [`MessageQueue`](#messagequeue) consumers listen on for patches applied to the DOM;
+- There is a channel to send patches and update the DOM;
 - And a `SessionId` to uniquely identify the `ServeSession`.
 
-All of the public interfaces via CLI of Rojo are implemented using `ServeSession`.
+The primary interface for a `ServeSession` is the web server used by the [`serve` command](#servecommand). Additionally, several of Rojo's commands are implemented using `ServeSession`.
+
+### MessageQueue
+
+`MessageQueue` manages a persistent history of messages and a way to subscribe asynchronously to messages past or future.
+
+It does this primarily by having the subscribers keep a cursor of the message they're currently on. So, when a subscription does occurs:
+
+- If the cursor is behind the latest message, it will be immediately be fired with all messages past the cursor;
+- If the cursor is on the latest message, it will fire on the next message given;
+- If the cursor is ahead of the latest message, it will fire on the message after the cursor.
+
+### SessionId
 
 ### ChangeProcessor
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,12 +6,12 @@ This document is a "what the heck is going on" level view of Rojo and the codeba
 
 ## Overarching
 
-Rojo is divide into several components, each layering on top of each other provide Rojo's functionality.
+Rojo is divided into several components, each layering on top of each other provide Rojo's functionality.
 
-At the core of Rojo, is `ServeSession`. As the name implies, it contains all of the components to keep a persistent DOM, react to events to update the DOM, and serve the DOM to consumers. It depends on:
+At the core of Rojo lies `ServeSession`. As the name implies, it contains all of the components to keep a persistent DOM, react to events to update the DOM, and serve the DOM to consumers. It depends on:
 
 - `RojoTree` to represent the DOM;
-- `Project` to represent your root project file (e.g. `default.project.json`).
+- `Project` to represent your root project file (e.g. `default.project.json`);
 - [`Vfs`](#vfs) to provide a filesystem and emit events on changes;
 - [`ChangeProcessor`](#changeprocessor) to process filesystem events from `Vfs` and consequently update the DOM through the [snapshotting system](#the-snapshotting-system);
 
@@ -39,13 +39,13 @@ Because snapshots are designed to be translated into Instances anyway, this syst
 
 ## Serve Command
 
-There are two main pieces in doing this: the server and the Studio Plugin.
+There are two main pieces in play when serving: the server and the Studio plugin.
 
-The server runs a local `LiveServer` on your computer (be it through a terminal, the visual studio extension, or a remote machine). It consumes a `ServeSession` and attaches a web server on top. The web server itself is very basic, consisting of around half a dozen endpoints. Generally, `LiveServer` acts as a middleman with the bulk of the work is performed by either the underlying `ServeSession` or the plugin. 
+The server runs a local `LiveServer` with access to your filesystem (whether it be via the terminal, the visual studio code extension, or a remote machine). It consumes a `ServeSession` and attaches a web server on top. The web server itself is very basic, consisting of around half a dozen endpoints. Generally, `LiveServer` acts as a middleman with the bulk of the work is performed by either the underlying `ServeSession` or the plugin. 
 
-To serve a project to a connecting plugin, the server gathers data on all of the files in that project, puts it into a nice format, and then sends it to the plugin. After that, when something changes on the file system, the underlying `ServeSession` emits new patches. The web server has a `api/subscribe` endpoint where the plugin [long polls](https://en.wikipedia.org/wiki/Push_technology#Long_polling) on to receive the patches from the server and apply them to the datamodel in Studio.
+To serve a project to a connecting plugin, the server gathers data on all of the files in that project, puts it into a nice format, and then sends it to the plugin. After that, when something changes on the file system, the underlying `ServeSession` emits new patches. The web server has a `api/subscribe` endpoint where the plugin [long polls](https://en.wikipedia.org/wiki/Push_technology#Long_polling) to receive the patches from the server and apply them to the datamodel in Studio.
 
-When the plugin receives a patch from the server (whether it be the initial patch or any subsequent ones), the plugin reads through the patch and attempts to to apply the changes described by it. Any sugar (the patch visualizer, as an example) happens on top of the patches received from the server.
+When the plugin receives a patch it reads through the patch contents and attempts to to apply the changes described by it. Any sugar (the patch visualizer, as an example) happens on top of the patches received from the server.
 
 ## The Plugin
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,8 +12,8 @@ At the core of Rojo, is `ServeSession`. As the name implies, it contains all of 
 
 - `RojoTree` to represent the DOM;
 - `Project` to represent your root project file (e.g. `default.project.json`).
-- `Vfs` to provide a filesystem and emit events on changes;
-- `ChangeProcessor` to process filesystem events from `Vfs` and consequently update the DOM through the snapshotting system;
+- [`Vfs`](#vfs) to provide a filesystem and emit events on changes;
+- [`ChangeProcessor`](#changeprocessor) to process filesystem events from `Vfs` and consequently update the DOM through the [snapshotting system](#the-snapshotting-system);
 
 It also provides an API for the higher level components so it can be used with the outside world.
 


### PR DESCRIPTION
Basis comes [from this comment from the main PR](https://github.com/rojo-rbx/rojo/pull/749#issuecomment-1652875974).

~~I need to move the description I put for `ServeSession` to the Data Structure section. I wrote on "what needs to be described first", so /shrug.~~

 Maybe we should describe each command in its own part under the Overarching section. It is the entry point for Rojo, after all.